### PR TITLE
feat: 자동 로그인 체크 여부에 따른 refresh token 만료 시간 차별화

### DIFF
--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -8,6 +8,7 @@ import { AuthService, OauthService } from './auth.service';
 import { JwtStrategy } from './jwt/jwt.strategy';
 import * as redisStore from 'cache-manager-redis-store';
 import { GoogleStrategy } from './passport/google/google.strategy';
+import { customJwtService } from './jwt/jwt.service';
 
 const accessTokenExpiration = '10m';
 export const refreshTokenExpiration = '30d';
@@ -31,7 +32,13 @@ export const verifyEmailExpiration = 60 * 5;
     }),
   ],
   controllers: [AuthController, OauthController],
-  providers: [AuthService, JwtStrategy, OauthService, GoogleStrategy],
+  providers: [
+    AuthService,
+    JwtStrategy,
+    OauthService,
+    GoogleStrategy,
+    customJwtService,
+  ],
   exports: [AuthService],
 })
 export class AuthModule {}

--- a/src/auth/dtos/login.dto.ts
+++ b/src/auth/dtos/login.dto.ts
@@ -1,9 +1,16 @@
 import { ApiProperty, PickType } from '@nestjs/swagger';
-import { IsOptional, IsString } from 'class-validator';
+import { IsBoolean, IsOptional, IsString } from 'class-validator';
 import { CoreOutput } from 'src/common/dtos/output.dto';
 import { User } from '../../users/entities/user.entity';
 
-export class LoginBodyDto extends PickType(User, ['email', 'password']) {}
+export class LoginBodyDto extends PickType(User, ['email', 'password']) {
+  @ApiProperty({
+    description: '자동 로그인 여부',
+    example: true,
+  })
+  @IsBoolean()
+  auto_login: boolean;
+}
 
 export class LoginOutput extends CoreOutput {
   @ApiProperty({ description: 'access token', required: false })

--- a/src/auth/jwt/jwt.payload.ts
+++ b/src/auth/jwt/jwt.payload.ts
@@ -1,4 +1,8 @@
 export class Payload {
-  email: string;
+  email: string; // user email
+  period: string; // '30d' or '2h' that indicates whether or not you are an auto-login user
   sub: number; // userId
 }
+
+export const ONEMONTH = '30d';
+export const TWOHOUR = '2h';

--- a/src/auth/jwt/jwt.service.ts
+++ b/src/auth/jwt/jwt.service.ts
@@ -1,0 +1,34 @@
+import { Injectable } from '@nestjs/common';
+import { JwtService, JwtVerifyOptions } from '@nestjs/jwt';
+import { refreshTokenExpiration } from '../auth.module';
+import { ONEMONTH, Payload, TWOHOUR } from './jwt.payload';
+
+@Injectable()
+export class customJwtService {
+  constructor(private readonly jwtService: JwtService) {}
+
+  sign(payload: Payload): string {
+    return this.jwtService.sign(payload);
+  }
+
+  verify(token: string, options?: JwtVerifyOptions): Payload {
+    return this.jwtService.verify(token, { secret: options.secret });
+  }
+
+  createPayload(email, autoLogin, sub): Payload {
+    const period: string = autoLogin ? ONEMONTH : TWOHOUR;
+
+    const payload: Payload = { email, period, sub };
+
+    return payload;
+  }
+
+  generateRefreshToken(payload: Payload): string {
+    const expiresIn: string =
+      payload.period === ONEMONTH ? refreshTokenExpiration : TWOHOUR;
+    return this.jwtService.sign(payload, {
+      secret: process.env.JWT_REFRESH_TOKEN_PRIVATE_KEY,
+      expiresIn,
+    });
+  }
+}


### PR DESCRIPTION
자동 로그인 체크 여부를 auto_login 값으로 받고
해당 값에 따라서 2시간 혹은 한달로
refresh token 만료 시간을 달리한다.

jwt payload 내에 period property를 추가하여
만료 기한을 명시해두었다.