### PR TITLE
improve: 한국 시간이라는 정보를 임의로 기입

### DIFF
--- a/src/common/logger.ts
+++ b/src/common/logger.ts
@@ -4,7 +4,9 @@ import * as DailyRotateFile from 'winston-daily-rotate-file';
 
 const { combine, label, printf, colorize } = winston.format;
 const logFormat = printf(({ level, label, message }) => {
-  return `[${label}] ${level}: ${getKoreaTime()} ${message}`;
+  return `[${label}] ${level}: ${
+    getKoreaTime().toUTCString().split(' GMT')[0]
+  } GMT+0900 (Korean Standard Time) ${message}`;
 });
 
 const custom_level = {


### PR DESCRIPTION
한국 시간임에도 불구하고
GMT+0000 (Coordinated Universal Time)라고 뜨는 현상을
강제로 해결